### PR TITLE
Added message logging capabilities

### DIFF
--- a/console/HassClient.Performance.Tests/Program.cs
+++ b/console/HassClient.Performance.Tests/Program.cs
@@ -61,8 +61,10 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
             {
                 builder
                     .ClearProviders()
-                    .AddFilter("HassClient.HassClient", LogLevel.Trace)
-                    .AddConsole();
+                    // .AddFilter("HassClient.HassClient", LogLevel.Trace)
+                    .AddConsole()
+                    .AddDebug()
+                    .SetMinimumLevel(LogLevel.Trace);
             });
 
             client = new HassClient(factory);
@@ -92,7 +94,8 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
                 await client.SubscribeToEvents();
             }
 
-            // var test = await client.CallService("light", "toggle", new { entity_id = "light.tomas_rum" });
+            await client.CallService("light", "toggle", new { entity_id = "light.tomas_rum" });
+            await client.CallService("light", "no_exist", new { entity_id = "light.tomas_rum_not_exist" });
             //var tt = await client.SetState("sensor.csharp", "cool", new {daemon = true});
 
             //var result = await client.SendEvent("test_event", new { data="hello" });


### PR DESCRIPTION
This PR includes message logging capabilities to HassClient.

The default behavior now is:
- When LogLevel.Trace then all messages are logged except event. This is so we do not flood the log
- Events can be turned on by setting the environment var HASSCLIENT_MSGLOGLEVEL=All
- All message logs can be turned off by setting the environment var HASSCLIENT_MSGLOGLEVEL=None