### PR TITLE
feat: use dependency injection for hassclient

### DIFF
--- a/src/HassClient/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HassClient/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,61 @@
+﻿using JoySoftware.HomeAssistant.Client;
+using JoySoftware.HomeAssistant.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+
+namespace JoySoftware.HomeAssistant.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddHassClient(this IServiceCollection services)
+        {
+            return services
+                .AddClientFactory()
+                .AddPipelineFactory()
+                .AddHttpFactory()
+                .AddHassClientImpl();
+        }
+
+        private static IServiceCollection AddHassClientImpl(this IServiceCollection services)
+        {
+            services.TryAddTransient<IHassClient>(provider =>
+            {
+                var loggerFactory = provider.GetService<ILoggerFactory>() ?? LoggerHelper.CreateDefaultLoggerFactory();
+                var pipelineFactory = provider.GetRequiredService<ITransportPipelineFactory<HassMessage>>();
+                var clientFactory = provider.GetRequiredService<IClientWebSocketFactory>();
+                var httpFactory = provider.GetRequiredService<IHttpClientFactory>();
+
+                return new HassClient(loggerFactory, pipelineFactory, clientFactory, httpFactory.CreateClient());
+            });
+
+            return services;
+        }
+
+        private static IServiceCollection AddClientFactory(this IServiceCollection services)
+        {
+            services.TryAddTransient<IClientWebSocketFactory, ClientWebSocketFactory>();
+            return services;
+        }
+
+        private static IServiceCollection AddPipelineFactory(this IServiceCollection services)
+        {
+            services.TryAddTransient<ITransportPipelineFactory<HassMessage>, WebSocketMessagePipelineFactory<HassMessage>>();
+            return services;
+        }
+
+        private static IServiceCollection AddHttpFactory(this IServiceCollection services)
+        {
+            services.AddHttpClient<IHassClient, HassClient>().ConfigurePrimaryHttpMessageHandler(ConfigureHttpMessageHandler);
+            return services;
+        }
+
+        private static HttpMessageHandler ConfigureHttpMessageHandler(IServiceProvider provider)
+        {
+            var handler = provider.GetService<HttpMessageHandler>();
+            return handler ?? HttpHelper.CreateHttpMessageHandler();
+        }
+    }
+}

--- a/src/HassClient/HassClient.csproj
+++ b/src/HassClient/HassClient.csproj
@@ -22,6 +22,7 @@
   </PropertyGroup>
 
    <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />

--- a/src/HassClient/Helpers/HttpHelper.cs
+++ b/src/HassClient/Helpers/HttpHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Security;
+
+namespace JoySoftware.HomeAssistant.Helpers
+{
+    internal static class HttpHelper
+    {
+        public static HttpClient CreateHttpClient()
+        {
+            return new(CreateHttpMessageHandler());
+        }
+        
+        public static HttpMessageHandler CreateHttpMessageHandler()
+        {
+            var bypassCertificateErrorsForHash = Environment.GetEnvironmentVariable("HASSCLIENT_BYPASS_CERT_ERR");
+            if (string.IsNullOrEmpty(bypassCertificateErrorsForHash))
+            {
+                return new HttpClientHandler();
+            }
+
+            return CreateHttpMessageHandler(bypassCertificateErrorsForHash);
+        }
+
+        private static HttpMessageHandler CreateHttpMessageHandler(string certificate)
+        {
+            return new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = (_, cert, _, sslPolicyErrors) =>
+                {
+                    if (sslPolicyErrors == SslPolicyErrors.None)
+                    {
+                        return true; //Is valid
+                    }
+
+                    return cert?.GetCertHashString() == certificate.ToUpperInvariant();
+                }
+            };
+        }
+    }
+}

--- a/src/HassClient/Helpers/LoggerHelper.cs
+++ b/src/HassClient/Helpers/LoggerHelper.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace JoySoftware.HomeAssistant.Helpers
+{
+    internal static class LoggerHelper
+    {
+        public static ILoggerFactory CreateDefaultLoggerFactory() => LoggerFactory.Create(builder => builder
+            .ClearProviders()
+            .AddFilter("HassClient.HassClient", LogLevel.Information)
+            .AddConsole()
+        );
+    }
+}

--- a/src/HassClient/Helpers/WebSocketHelper.cs
+++ b/src/HassClient/Helpers/WebSocketHelper.cs
@@ -1,0 +1,17 @@
+﻿using JoySoftware.HomeAssistant.Client;
+
+namespace JoySoftware.HomeAssistant.Helpers
+{
+    internal static class WebSocketHelper
+    {
+        public static ITransportPipelineFactory<HassMessage> CreatePipelineFactory()
+        {
+            return new WebSocketMessagePipelineFactory<HassMessage>();
+        }
+
+        public static IClientWebSocketFactory CreateClientFactory()
+        {
+            return new ClientWebSocketFactory();
+        }
+    }
+}

--- a/tests/HassClient.Integration.Tests/HassClientIntegrationTests.csproj
+++ b/tests/HassClient.Integration.Tests/HassClientIntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR enables dependency injection as a first class citizen in net-hassclient.