### PR TITLE
added support for trigger webhook

### DIFF
--- a/console/HassClient.Performance.Tests/HassClient.Performance.Tests.csproj
+++ b/console/HassClient.Performance.Tests/HassClient.Performance.Tests.csproj
@@ -39,7 +39,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/console/HassClient.Performance.Tests/Program.cs
+++ b/console/HassClient.Performance.Tests/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using HassClientIntegrationTests.Mocks;
 using JoySoftware.HomeAssistant.Extensions;
@@ -48,6 +49,11 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
             return cmd;
         }
 
+        public record EventData
+        {
+            [JsonPropertyName("temperature")]
+            public double Temperature { get; set; }
+        }
         private static async Task ConnectToHomeAssistant(string ip, short port, bool events, string token)
         {
             // Environment.SetEnvironmentVariable("HASSCLIENT_BYPASS_CERT_ERR", "BFCC28167558E74CD0AA3045719E158D2B21F79E");
@@ -68,13 +74,11 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
             {
                 Console.WriteLine($"Number of states: {client.States.Count}");
             }
-
-            var x = await client.GetState("sensor.temp_outside");
-
-            var services = await client.GetServices();
-
-            var config = await client.GetConfig();
-            System.Console.WriteLine(config.State);
+            
+            var data = new EventData {Temperature=4.3};
+            await client.TriggerWebhook("my-super-secret-id", data);
+            // await client.TriggerWebhook("my-super-secret-id", new {temperature = 4.1});
+           
             // var test = client.States["group.chromecasts"];
             if (events)
             {

--- a/src/HassClient/Client/HassClient.cs
+++ b/src/HassClient/Client/HassClient.cs
@@ -647,15 +647,16 @@ namespace JoySoftware.HomeAssistant.Client
             var apiUrl = $"{_apiUrl}/{apiPath}";
             var content = "";
 
-            if (data != null)
-            {
-                content = JsonSerializer.Serialize(data, _defaultSerializerOptions);
-            }
-
             try
             {
                 using var sc = new StringContent(content, Encoding.UTF8);
-                sc.Headers.ContentType = new MediaTypeWithQualityHeaderValue("application/json");
+
+                if (data != null)
+                {
+                    content = JsonSerializer.Serialize(data, _defaultSerializerOptions);
+                    sc.Headers.ContentType = new MediaTypeWithQualityHeaderValue("application/json");
+                }
+
                 var result = await _httpClient.PostAsync(new Uri(apiUrl),
                     sc,
                     CancelSource.Token).ConfigureAwait(false);

--- a/src/HassClient/Client/HassClient.cs
+++ b/src/HassClient/Client/HassClient.cs
@@ -118,6 +118,13 @@ namespace JoySoftware.HomeAssistant.Client
         public Task<T?> PostApiCall<T>(string apiPath, object? data = null);
 
         /// <summary>
+        ///     Trigger a state change using trigger templates
+        /// </summary>
+        /// <param name="id">webhook id</param>
+        /// <param name="data">data being sent</param>
+        public Task TriggerWebhook(string id, object? data);
+
+        /// <summary>
         ///     Gets all registered Entities from entity registry from Home Assistant
         /// </summary>
         Task<HassEntities> GetEntities();
@@ -648,14 +655,21 @@ namespace JoySoftware.HomeAssistant.Client
             try
             {
                 using var sc = new StringContent(content, Encoding.UTF8);
-
+                sc.Headers.ContentType = new MediaTypeWithQualityHeaderValue("application/json");
                 var result = await _httpClient.PostAsync(new Uri(apiUrl),
                     sc,
                     CancelSource.Token).ConfigureAwait(false);
 
                 if (result.IsSuccessStatusCode)
                 {
-                    return await JsonSerializer.DeserializeAsync<T>(result.Content.ReadAsStream(), null, CancelSource.Token).ConfigureAwait(false);
+                    if (result.Content.Headers.ContentLength > 0)
+                    {
+                        return await JsonSerializer.DeserializeAsync<T>(result.Content.ReadAsStream(), null, CancelSource.Token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        return default;
+                    }
                 }
             }
             catch (Exception e)
@@ -1082,6 +1096,13 @@ namespace JoySoftware.HomeAssistant.Client
             {
                 // Ignore errors
             }
+        }
+
+        /// <inheritdoc/>
+        public async Task TriggerWebhook(string id, object? data)
+        {
+            var encodedId = HttpUtility.UrlEncode(id);
+            await PostApiCall<object>($"webhook/{encodedId}", data ).ConfigureAwait(false);
         }
     }
 }

--- a/tests/HassClient.Unit.Tests/HassClientTests.cs
+++ b/tests/HassClient.Unit.Tests/HassClientTests.cs
@@ -954,6 +954,85 @@ namespace HassClient.Unit.Tests
         }
 
         [Fact]
+        public async Task HttpClientShouldCallCorrectHttpMessageHandlerOnWebhooks()
+        {
+            // ARRANGE
+            var mock = new HassWebSocketMock();
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            httpMessageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(
+                    () => new HttpResponseMessage()
+                    {
+                        StatusCode = HttpStatusCode.OK, // Set non success return code
+                    }); ;
+
+            // Get the default state hass client
+            await using var hassClient = await mock.GetHassConnectedClient(false, httpMessageHandlerMock.Object).ConfigureAwait(false);
+
+            await hassClient.TriggerWebhook("secret_id", new { attribute = "hello" }).ConfigureAwait(false);
+
+            // ACT and ASSERT
+            // Calls connect without getting the states initially
+            httpMessageHandlerMock.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Exactly(1), // we expected a single external request
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                            req.Method == HttpMethod.Post // we expected a GET request
+                            && req.RequestUri ==
+                            new Uri("http://anyurldoesntmatter.org/api/webhook/secret_id") // to this uri
+                    ),
+                    ItExpr.IsAny<CancellationToken>()
+                );
+        }
+        class WebHookData {
+            public WebHookData(double temperature) 
+            {
+                this.temperature = temperature;
+            }
+            public readonly double temperature;
+        }
+
+        [Fact]
+        public async Task HttpClientShouldCallCorrectHttpMessageHandlerUsingClassOnWebhooks()
+        {
+            // ARRANGE
+            var mock = new HassWebSocketMock();
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            httpMessageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(
+                    () => new HttpResponseMessage()
+                    {
+                        StatusCode = HttpStatusCode.OK, // Set non success return code
+                    }); ;
+
+            // Get the default state hass client
+            await using var hassClient = await mock.GetHassConnectedClient(false, httpMessageHandlerMock.Object).ConfigureAwait(false);
+            WebHookData data = new(4);
+            await hassClient.TriggerWebhook("secret_id", data).ConfigureAwait(false);
+
+            // ACT and ASSERT
+            // Calls connect without getting the states initially
+            httpMessageHandlerMock.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Exactly(1), // we expected a single external request
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                            req.Method == HttpMethod.Post // we expected a GET request
+                            && req.RequestUri ==
+                            new Uri("http://anyurldoesntmatter.org/api/webhook/secret_id") // to this uri
+                    ),
+                    ItExpr.IsAny<CancellationToken>()
+                );
+        }
+
+        [Fact]
         public async Task SetStateNonSuccessHttpResponseCodeReturnNull()
         {
 


### PR DESCRIPTION
# Webhook triggers support
This PR handles webhook triggers. This is implemented in the HassClient and will be supported in NetDaemon when this is merged.

## Usage
Make a trigger template webhook sensor in HA

```yaml
template:
  - trigger:
      - platform: webhook
        webhook_id: my-super-secret-id
    sensor:
      - name: "NetDaemon webhook temp sensor"
        state: "{{ trigger.json.temperature }}"
        unit_of_measurement: °C
```
Use following code to trigger it:

```cs
public record TriggerData
{
   [JsonPropertyName("temperature")]
   public double Temperature { get; set; }
}

var data = new TriggerData {Temperature=4.3};
// trigger using record
await client.TriggerWebhook("my-super-secret-id", data);
// trigger using anon class
await client.TriggerWebhook("my-super-secret-id", new {temperature = 4.1});
```
