### PR TITLE
Support target in call_service

### DIFF
--- a/console/HassClient.Performance.Tests/Program.cs
+++ b/console/HassClient.Performance.Tests/Program.cs
@@ -74,11 +74,11 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
             {
                 Console.WriteLine($"Number of states: {client.States.Count}");
             }
-            
-            var data = new EventData {Temperature=4.3};
-            await client.TriggerWebhook("my-super-secret-id", data);
+
+            // var data = new EventData {Temperature=4.3};
+            // await client.TriggerWebhook("my-super-secret-id", data);
             // await client.TriggerWebhook("my-super-secret-id", new {temperature = 4.1});
-           
+
             // var test = client.States["group.chromecasts"];
             if (events)
             {
@@ -86,7 +86,7 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
                 await client.SubscribeToEvents();
             }
 
-            // await client.CallService("light", "toggle", new { entity_id = "light.tomas_rum" });
+            await client.CallService("light", "toggle", null, new HassTarget { AreaIds = new string[] { "bedroom" } });
             // await client.CallService("light", "no_exist", new { entity_id = "light.tomas_rum_not_exist" });
             //var tt = await client.SetState("sensor.csharp", "cool", new {daemon = true});
 
@@ -149,7 +149,7 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
                 .AddDebug()
                 .SetMinimumLevel(LogLevel.Trace));
         }
-        
+
         public class Discovery
         {
             public string base_url { get; set; }

--- a/console/HassClient.Performance.Tests/Program.cs
+++ b/console/HassClient.Performance.Tests/Program.cs
@@ -109,7 +109,6 @@ namespace JoySoftware.HomeAssistant.Client.Performance.Tests
                     else if (eventMsg.EventType == "call_service")
                     {
                         var serviceMessage = eventMsg?.Data as HassServiceEventData;
-                        serviceMessage.ServiceData = null;
                         Console.WriteLine($"{serviceMessage.Service}: {serviceMessage.ServiceData}");
                     }
                     else

--- a/src/HassClient/Client/HassClient.cs
+++ b/src/HassClient/Client/HassClient.cs
@@ -336,7 +336,7 @@ namespace JoySoftware.HomeAssistant.Client
         //     await CallService(domain, service, serviceData, null, waitForResponse);
 
         /// <inheritdoc/>
-        public async Task<bool> CallService(string domain, string service, object? serviceData, HassTarget? target = null, bool waitForResponse = true)
+        public async Task<bool> CallService(string domain, string service, object? serviceData = null, HassTarget? target = null, bool waitForResponse = true)
         {
             try
             {

--- a/src/HassClient/Client/HassClient.cs
+++ b/src/HassClient/Client/HassClient.cs
@@ -91,7 +91,7 @@ namespace JoySoftware.HomeAssistant.Client
         /// <summary>
         ///     Gets the configuration of the connected Home Assistant instance
         /// </summary>
-        Task<IEnumerable<HassServiceDomain>> GetServices();
+        Task<IReadOnlyCollection<HassServiceDomain>> GetServices();
 
         /// <summary>
         ///     Gets all registered Areas from Home Assistant
@@ -189,7 +189,7 @@ namespace JoySoftware.HomeAssistant.Client
         ///     Get all state for all entities in Home Assistant
         /// </summary>
         /// <param name="token">Provided token</param>
-        Task<IEnumerable<HassState>> GetAllStates(CancellationToken? token = null);
+        Task<IReadOnlyCollection<HassState>> GetAllStates(CancellationToken? token = null);
     }
 
     /// <summary>
@@ -749,11 +749,11 @@ namespace JoySoftware.HomeAssistant.Client
             }
         }
 
-        public async Task<IEnumerable<HassServiceDomain>> GetServices()
+        public async Task<IReadOnlyCollection<HassServiceDomain>> GetServices()
         {
             HassMessage servicesResult = await SendCommandAndWaitForResponse(new GetServicesCommand()).ConfigureAwait(false);
 
-            return servicesResult.Result as IEnumerable<HassServiceDomain>
+            return servicesResult.Result as IReadOnlyCollection<HassServiceDomain>
                     ?? throw new ApplicationException("Unexpected response from GetServices command");
         }
 
@@ -991,7 +991,7 @@ namespace JoySoftware.HomeAssistant.Client
 
             return m;
         }
-        public async Task<IEnumerable<HassState>> GetAllStates(CancellationToken? token = null)
+        public async Task<IReadOnlyCollection<HassState>> GetAllStates(CancellationToken? token = null)
         {
             var tokenToUse = token ?? CancelSource.Token;
 

--- a/src/HassClient/Helpers/HttpHelper.cs
+++ b/src/HassClient/Helpers/HttpHelper.cs
@@ -10,7 +10,6 @@ namespace JoySoftware.HomeAssistant.Helpers
         {
             return new(CreateHttpMessageHandler());
         }
-        
         public static HttpMessageHandler CreateHttpMessageHandler()
         {
             var bypassCertificateErrorsForHash = Environment.GetEnvironmentVariable("HASSCLIENT_BYPASS_CERT_ERR");

--- a/src/HassClient/Helpers/Json/HassDeviceModelConverter.cs
+++ b/src/HassClient/Helpers/Json/HassDeviceModelConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,17 +12,17 @@ namespace JoySoftware.HomeAssistant.Helpers.Json
             if (reader.TokenType == JsonTokenType.Number)
             {
                 var stringValue = reader.GetInt32();
-                return stringValue.ToString();
+                return stringValue.ToString(CultureInfo.InvariantCulture);
             }
             else if (reader.TokenType == JsonTokenType.String)
             {
                 return reader.GetString();
             }
- 
+
             throw new System.Text.Json.JsonException();
         }
 
         public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) =>
-            writer.WriteStringValue(value);
+            writer?.WriteStringValue(value);
     }
 }

--- a/src/HassClient/Helpers/Json/HassEventConverter.cs
+++ b/src/HassClient/Helpers/Json/HassEventConverter.cs
@@ -23,7 +23,6 @@ namespace JoySoftware.HomeAssistant.Helpers.Json
             {
                 m.Data = m.DataElement?.ToObject<HassServiceEventData>(options);
                 if (m.Data != null)
-                    
                     ((HassServiceEventData)m.Data).Data = ((HassServiceEventData)m.Data).ServiceData?.ToDynamic();
             }
             else

--- a/src/HassClient/Helpers/Json/HassEventConverter.cs
+++ b/src/HassClient/Helpers/Json/HassEventConverter.cs
@@ -23,6 +23,7 @@ namespace JoySoftware.HomeAssistant.Helpers.Json
             {
                 m.Data = m.DataElement?.ToObject<HassServiceEventData>(options);
                 if (m.Data != null)
+                    
                     ((HassServiceEventData)m.Data).Data = ((HassServiceEventData)m.Data).ServiceData?.ToDynamic();
             }
             else

--- a/src/HassClient/Helpers/Json/JsonExtensions.cs
+++ b/src/HassClient/Helpers/Json/JsonExtensions.cs
@@ -77,7 +77,7 @@ namespace JoySoftware.HomeAssistant.Helpers.Json
             {
                 element.WriteTo(writer);
             }
-            
+
             return JsonSerializer.Deserialize<T>(bufferWriter.WrittenSpan, options) ?? default!;
         }
 
@@ -110,7 +110,7 @@ namespace JoySoftware.HomeAssistant.Helpers.Json
                 result.Add(serviceDomain);
             }
 
-            IEnumerable<HassService> getServices(JsonElement element)
+            IReadOnlyCollection<HassService> getServices(JsonElement element)
             {
                 var servicesList = new List<HassService>();
                 foreach (var serviceDomainProperty in element.EnumerateObject())

--- a/src/HassClient/Helpers/Json/JsonExtensions.cs
+++ b/src/HassClient/Helpers/Json/JsonExtensions.cs
@@ -88,12 +88,11 @@ namespace JoySoftware.HomeAssistant.Helpers.Json
             return JsonDocument.Parse(json).RootElement;
         }
 
-
         /// <summary>
         ///     Parses all json elements to instance result from GetServices call
         /// </summary>
         /// <param name="element">JsonElement containing the result data</param>
-        public static IEnumerable<HassServiceDomain> ToServicesResult(this JsonElement element)
+        public static IReadOnlyCollection<HassServiceDomain> ToServicesResult(this JsonElement element)
         {
             var result = new List<HassServiceDomain>();
 

--- a/src/HassClient/Messages/CallServiceCommand.cs
+++ b/src/HassClient/Messages/CallServiceCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using JoySoftware.HomeAssistant.Model;
+using System.Text.Json.Serialization;
 
 namespace JoySoftware.HomeAssistant.Messages
 {
@@ -14,5 +15,8 @@ namespace JoySoftware.HomeAssistant.Messages
 
         [JsonPropertyName("service_data")]
         public object? ServiceData { get; set; }
+
+        [JsonPropertyName("target")]
+        public HassTarget? Target { get; set; }
     }
 }

--- a/src/HassClient/Messages/CallServiceCommand.cs
+++ b/src/HassClient/Messages/CallServiceCommand.cs
@@ -8,15 +8,15 @@ namespace JoySoftware.HomeAssistant.Messages
         public CallServiceCommand() => Type = "call_service";
 
         [JsonPropertyName("domain")]
-        public string Domain { get; set; } = string.Empty;
+        public string Domain { get; init; } = string.Empty;
 
         [JsonPropertyName("service")]
-        public string Service { get; set; } = string.Empty;
+        public string Service { get; init; } = string.Empty;
 
         [JsonPropertyName("service_data")]
-        public object? ServiceData { get; set; }
+        public object? ServiceData { get; init; }
 
         [JsonPropertyName("target")]
-        public HassTarget? Target { get; set; }
+        public HassTarget? Target { get; init; }
     }
 }

--- a/src/HassClient/Messages/HassAuthMessage.cs
+++ b/src/HassClient/Messages/HassAuthMessage.cs
@@ -7,6 +7,6 @@ namespace JoySoftware.HomeAssistant.Messages
         public HassAuthMessage() => Type = "auth";
 
         [JsonPropertyName("access_token")]
-        public string AccessToken { get; set; } = string.Empty;
+        public string AccessToken { get; init; } = string.Empty;
     }
 }

--- a/src/HassClient/Messages/SubscribeEventCommand.cs
+++ b/src/HassClient/Messages/SubscribeEventCommand.cs
@@ -7,6 +7,6 @@ namespace JoySoftware.HomeAssistant.Messages
         public SubscribeEventCommand() => Type = "subscribe_events";
 
         [JsonPropertyName("event_type")]
-        public string? EventType { get; set; }
+        public string? EventType { get; init; }
     }
 }

--- a/src/HassClient/Model/EventType.cs
+++ b/src/HassClient/Model/EventType.cs
@@ -11,6 +11,8 @@
         CallService = 6,
         ServiceExecuted = 7,
         PlatformDiscovered = 8,
-        ComponentLoaded = 9
+        ComponentLoaded = 9,
+        AutomationReloaded = 10,
+        SceneReloaded = 11
     }
 }

--- a/src/HassClient/Model/HassArea.cs
+++ b/src/HassClient/Model/HassArea.cs
@@ -3,16 +3,12 @@ using System.Text.Json.Serialization;
 
 namespace JoySoftware.HomeAssistant.Model
 {
-    public class HassAreas : List<HassArea>
-    {
-    }
-    
     public record HassArea
     {
         [JsonPropertyName("name")]
-        public string? Name { get; set; }
+        public string? Name { get; init; }
 
         [JsonPropertyName("area_id")]
-        public string? Id { get; set; }
+        public string? Id { get; init; }
     }
 }

--- a/src/HassClient/Model/HassConfig.cs
+++ b/src/HassClient/Model/HassConfig.cs
@@ -6,7 +6,7 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassConfig
     {
         [JsonPropertyName("components")]
-        public IEnumerable<string>? Components { get; init; }
+        public IReadOnlyCollection<string>? Components { get; init; }
 
         [JsonPropertyName("config_dir")]
         public string? ConfigDir { get; init; }

--- a/src/HassClient/Model/HassConfig.cs
+++ b/src/HassClient/Model/HassConfig.cs
@@ -6,7 +6,7 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassConfig
     {
         [JsonPropertyName("components")]
-        public IList<string>? Components { get; init; }
+        public IEnumerable<string>? Components { get; init; }
 
         [JsonPropertyName("config_dir")]
         public string? ConfigDir { get; init; }
@@ -36,6 +36,6 @@ namespace JoySoftware.HomeAssistant.Model
         public string? State { get; init; }
 
         [JsonPropertyName("whitelist_external_dirs")]
-        public IList<string>? WhitelistExternalDirs { get; init; }
+        public IEnumerable<string>? WhitelistExternalDirs { get; init; }
     }
 }

--- a/src/HassClient/Model/HassConfig.cs
+++ b/src/HassClient/Model/HassConfig.cs
@@ -36,6 +36,6 @@ namespace JoySoftware.HomeAssistant.Model
         public string? State { get; init; }
 
         [JsonPropertyName("whitelist_external_dirs")]
-        public IEnumerable<string>? WhitelistExternalDirs { get; init; }
+        public IReadOnlyCollection<string>? WhitelistExternalDirs { get; init; }
     }
 }

--- a/src/HassClient/Model/HassContext.cs
+++ b/src/HassClient/Model/HassContext.cs
@@ -5,12 +5,12 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassContext
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; } = string.Empty;
+        public string Id { get; init; } = string.Empty;
 
         [JsonPropertyName("parent_id")]
-        public string? ParentId { get; set; }
+        public string? ParentId { get; init; }
 
         [JsonPropertyName("user_id")]
-        public string? UserId { get; set; }
+        public string? UserId { get; init; }
     }
 }

--- a/src/HassClient/Model/HassDevice.cs
+++ b/src/HassClient/Model/HassDevice.cs
@@ -4,29 +4,25 @@ using System.Text.Json.Serialization;
 
 namespace JoySoftware.HomeAssistant.Model
 {
-    public class HassDevices : List<HassDevice>
-    {
-    }
-    
     public record HassDevice
     {
         [JsonPropertyName("manufacturer")]
-        public string? Manufacturer { get; set; }
+        public string? Manufacturer { get; init; }
 
         [JsonPropertyName("model")]
         [JsonConverter(typeof(HassDeviceModelConverter))]
-        public string? Model { get; set; }
+        public string? Model { get; init; }
 
         [JsonPropertyName("id")]
-        public string? Id { get; set; }
+        public string? Id { get; init; }
 
         [JsonPropertyName("area_id")]
-        public string? AreaId { get; set; }
+        public string? AreaId { get; init; }
 
         [JsonPropertyName("name")]
-        public string? Name { get; set; }
+        public string? Name { get; init; }
 
         [JsonPropertyName("name_by_user")]
-        public string? NameByUser { get; set; }
+        public string? NameByUser { get; init; }
     }
 }

--- a/src/HassClient/Model/HassEntity.cs
+++ b/src/HassClient/Model/HassEntity.cs
@@ -3,25 +3,21 @@ using System.Text.Json.Serialization;
 
 namespace JoySoftware.HomeAssistant.Model
 {
-    public class HassEntities : List<HassEntity>
-    {
-    }
-
     public record HassEntity
     {
         [JsonPropertyName("device_id")]
-        public string? DeviceId { get; set; }
+        public string? DeviceId { get; init; }
 
         [JsonPropertyName("entity_id")]
-        public string? EntityId { get; set; }
+        public string? EntityId { get; init; }
 
         [JsonPropertyName("name")]
-        public string? Name { get; set; }
+        public string? Name { get; init; }
 
         [JsonPropertyName("icon")]
-        public string? Icon { get; set; }
+        public string? Icon { get; init; }
 
         [JsonPropertyName("platform")]
-        public string? Platform { get; set; }
+        public string? Platform { get; init; }
     }
 }

--- a/src/HassClient/Model/HassError.cs
+++ b/src/HassClient/Model/HassError.cs
@@ -5,9 +5,9 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassError
     {
         [JsonPropertyName("code")]
-        public object? Code { get; set; }
+        public object? Code { get; init; }
 
         [JsonPropertyName("message")]
-        public string? Message { get; set; }
+        public string? Message { get; init; }
     }
 }

--- a/src/HassClient/Model/HassEvent.cs
+++ b/src/HassClient/Model/HassEvent.cs
@@ -6,7 +6,7 @@ namespace JoySoftware.HomeAssistant.Model
 {
     public record HassEvent
     {
-        public dynamic? Data { get; set; }
+        public dynamic? Data { get; set; } // keeping set cause it is created after serialization
 
         [JsonPropertyName("data")]
         public JsonElement? DataElement { get; init; }

--- a/src/HassClient/Model/HassService.cs
+++ b/src/HassClient/Model/HassService.cs
@@ -5,9 +5,7 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassService
     {
         public string? Service { get; init; }
-        
         public string? Description { get; init; }
-        
         public IEnumerable<HassServiceField>? Fields { get; init; }
     }
 }

--- a/src/HassClient/Model/HassService.cs
+++ b/src/HassClient/Model/HassService.cs
@@ -6,6 +6,6 @@ namespace JoySoftware.HomeAssistant.Model
     {
         public string? Service { get; init; }
         public string? Description { get; init; }
-        public IEnumerable<HassServiceField>? Fields { get; init; }
+        public IReadOnlyCollection<HassServiceField>? Fields { get; init; }
     }
 }

--- a/src/HassClient/Model/HassServiceDomain.cs
+++ b/src/HassClient/Model/HassServiceDomain.cs
@@ -5,6 +5,6 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassServiceDomain
     {
         public string? Domain { get; init; }
-        public IEnumerable<HassService>? Services { get; init; }
+        public IReadOnlyCollection<HassService>? Services { get; init; }
     }
 }

--- a/src/HassClient/Model/HassServiceDomain.cs
+++ b/src/HassClient/Model/HassServiceDomain.cs
@@ -5,7 +5,6 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassServiceDomain
     {
         public string? Domain { get; init; }
-        
         public IEnumerable<HassService>? Services { get; init; }
     }
 }

--- a/src/HassClient/Model/HassServiceEventData.cs
+++ b/src/HassClient/Model/HassServiceEventData.cs
@@ -6,13 +6,13 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassServiceEventData
     {
         [JsonPropertyName("domain")]
-        public string Domain { get; set; } = string.Empty;
+        public string Domain { get; init; } = string.Empty;
 
         [JsonPropertyName("service")]
-        public string Service { get; set; } = string.Empty;
+        public string Service { get; init; } = string.Empty;
 
         [JsonPropertyName("service_data")]
-        public JsonElement? ServiceData { get; set; }
+        public JsonElement? ServiceData { get; init; }
 
         public dynamic? Data { get; set; }
     }

--- a/src/HassClient/Model/HassServiceField.cs
+++ b/src/HassClient/Model/HassServiceField.cs
@@ -3,9 +3,7 @@
     public record HassServiceField
     {
         public string? Field { get; init; }
-        
         public string? Description { get; init; }
-        
         public object? Example { get; init; }
     }
 }

--- a/src/HassClient/Model/HassState.cs
+++ b/src/HassClient/Model/HassState.cs
@@ -7,9 +7,6 @@ using System.Text.Json.Serialization;
 
 namespace JoySoftware.HomeAssistant.Model
 {
-    public class HassStates : List<HassState>
-    {
-    }
     public record HassState
     {
         [JsonPropertyName("attributes")] public JsonElement? AttributesJson { get; set; }
@@ -22,11 +19,11 @@ namespace JoySoftware.HomeAssistant.Model
 
         public T? AttributesAs<T>() => AttributesJson.HasValue ? AttributesJson.Value.ToObject<T>() : default;
 
-        [JsonPropertyName("entity_id")] public string EntityId { get; set; } = "";
+        [JsonPropertyName("entity_id")] public string EntityId { get; init; } = "";
 
-        [JsonPropertyName("last_changed")] public DateTime LastChanged { get; set; } = DateTime.MinValue;
-        [JsonPropertyName("last_updated")] public DateTime LastUpdated { get; set; } = DateTime.MinValue;
-        [JsonPropertyName("state")] public string? State { get; set; } = "";
-        [JsonPropertyName("context")] public HassContext? Context { get; set; }
+        [JsonPropertyName("last_changed")] public DateTime LastChanged { get; init; } = DateTime.MinValue;
+        [JsonPropertyName("last_updated")] public DateTime LastUpdated { get; init; } = DateTime.MinValue;
+        [JsonPropertyName("state")] public string? State { get; init; } = "";
+        [JsonPropertyName("context")] public HassContext? Context { get; init; }
     }
 }

--- a/src/HassClient/Model/HassState.cs
+++ b/src/HassClient/Model/HassState.cs
@@ -10,7 +10,6 @@ namespace JoySoftware.HomeAssistant.Model
     public class HassStates : List<HassState>
     {
     }
-    
     public record HassState
     {
         [JsonPropertyName("attributes")] public JsonElement? AttributesJson { get; set; }

--- a/src/HassClient/Model/HassStateChangedEventData.cs
+++ b/src/HassClient/Model/HassStateChangedEventData.cs
@@ -6,12 +6,12 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassStateChangedEventData
     {
         [JsonPropertyName("entity_id")]
-        public string EntityId { get; set; } = "";
+        public string EntityId { get; init; } = "";
 
         [JsonPropertyName("new_state")]
-        public HassState? NewState { get; set; }
+        public HassState? NewState { get; init; }
 
         [JsonPropertyName("old_state")]
-        public HassState? OldState { get; set; }
+        public HassState? OldState { get; init; }
     }
 }

--- a/src/HassClient/Model/HassUnitSystem.cs
+++ b/src/HassClient/Model/HassUnitSystem.cs
@@ -5,15 +5,15 @@ namespace JoySoftware.HomeAssistant.Model
     public record HassUnitSystem
     {
         [JsonPropertyName("length")]
-        public string? Length { get; set; }
+        public string? Length { get; init; }
 
         [JsonPropertyName("mass")]
-        public string? Mass { get; set; }
+        public string? Mass { get; init; }
 
         [JsonPropertyName("temperature")]
-        public string? Temperature { get; set; }
+        public string? Temperature { get; init; }
 
         [JsonPropertyName("volume")]
-        public string? Volume { get; set; }
+        public string? Volume { get; init; }
     }
 }

--- a/src/HassClient/Model/Targets.cs
+++ b/src/HassClient/Model/Targets.cs
@@ -12,18 +12,18 @@ namespace JoySoftware.HomeAssistant.Model
         ///     Zero or more entity id to target with the service call
         /// </summary>
         [JsonPropertyName("entity_id")]
-        public IEnumerable<string>? EntityIds { get; init; }
+        public IReadOnlyCollection<string>? EntityIds { get; init; }
 
         /// <summary>
         ///     Zero or more device id to target with the service call
         /// </summary>
         [JsonPropertyName("device_id")]
-        public IEnumerable<string>? DeviceIds { get; init; }
+        public IReadOnlyCollection<string>? DeviceIds { get; init; }
 
         /// <summary>
         ///     Zero or more area id to target with the service call
         /// </summary>
         [JsonPropertyName("area_id")]
-        public IEnumerable<string>? AreaIds { get; init; }
+        public IReadOnlyCollection<string>? AreaIds { get; init; }
     }
 }

--- a/src/HassClient/Model/Targets.cs
+++ b/src/HassClient/Model/Targets.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace JoySoftware.HomeAssistant.Model
+{
+    /// <summary>
+    ///     Represents a target for a service call in Home Assistant
+    /// </summary>
+    public record HassTarget()
+    {
+        /// <summary>
+        ///     Zero or more entity id to target with the service call
+        /// </summary>
+        [JsonPropertyName("entity_id")]
+        public IEnumerable<string>? EntityIds { get; init; }
+
+        /// <summary>
+        ///     Zero or more device id to target with the service call
+        /// </summary>
+        [JsonPropertyName("device_id")]
+        public IEnumerable<string>? DeviceIds { get; init; }
+
+        /// <summary>
+        ///     Zero or more area id to target with the service call
+        /// </summary>
+        [JsonPropertyName("area_id")]
+        public IEnumerable<string>? AreaIds { get; init; }
+    }
+}

--- a/tests/HassClient.Unit.Tests/HassClientTests.cs
+++ b/tests/HassClient.Unit.Tests/HassClientTests.cs
@@ -112,7 +112,7 @@ namespace HassClient.Unit.Tests
                                     }");
 
             // ACT
-            var result = await hassClient.CallService("light", "turn_on", new { entity_id = "light.tomas_rum" }).ConfigureAwait(false);
+            var result = await hassClient.CallService("light", "turn_on", null, target: new HassTarget { EntityIds = new string[] { "light.test" } }).ConfigureAwait(false);
 
             // Assert
             Assert.True(result);
@@ -141,7 +141,7 @@ namespace HassClient.Unit.Tests
                                     }");
 
             // ACT
-            var result = await hassClient.CallService("light", "turn_on", new { entity_id = "light.tomas_rum" }, false).ConfigureAwait(false);
+            var result = await hassClient.CallService("light", "turn_on", new { entity_id = "light.tomas_rum" }, waitForResponse: false).ConfigureAwait(false);
 
             // Assert
             Assert.True(result);
@@ -1025,8 +1025,9 @@ namespace HassClient.Unit.Tests
                 );
         }
 
-        class WebHookData {
-            public WebHookData(double temperature) 
+        class WebHookData
+        {
+            public WebHookData(double temperature)
             {
                 this.temperature = temperature;
             }

--- a/tests/HassClient.Unit.Tests/HassClientTests.cs
+++ b/tests/HassClient.Unit.Tests/HassClientTests.cs
@@ -82,7 +82,7 @@ namespace HassClient.Unit.Tests
             // Do not add a fake service call message result
 
             // ACT
-            var callServiceTask = hassClient.CallService("light", "turn_on", new { entity_id = "light.tomas_rum" });
+            var callServiceTask = hassClient.CallService("light", "turn_on", target: new HassTarget { EntityIds = new string[] { "light.tomas_rum" } });
             hassClient.CancelSource.Cancel();
 
             // ASSERT


### PR DESCRIPTION
Basic support for correct API using target for different targets when using `call_service`message in websocket API. 

This PR is breaking but I think it should be ok for HassClient. Changes made:
- Adding the target in CallService (breaking). It is specifically when using waitFroResponse it will break. We can still use entity_id in service data instead of target.
- Small code smell fixes
- Added the Target record to support serialization of target data
- Made serviceData nullable so it will not be rendered in the final json if not provided
- Use IReadOnlyCollection instead of IEnumerable
- Change set to init where possible
