### PR TITLE
Add area_id from entity result

### DIFF
--- a/src/HassClient/Model/HassEntity.cs
+++ b/src/HassClient/Model/HassEntity.cs
@@ -11,6 +11,9 @@ namespace JoySoftware.HomeAssistant.Model
         [JsonPropertyName("entity_id")]
         public string? EntityId { get; init; }
 
+        [JsonPropertyName("area_id")]
+        public string? AreaId { get; init; }
+
         [JsonPropertyName("name")]
         public string? Name { get; init; }
 

--- a/tests/HassClient.Unit.Tests/Fixtures/Messages/result_get_entities.json
+++ b/tests/HassClient.Unit.Tests/Fixtures/Messages/result_get_entities.json
@@ -8,6 +8,7 @@
             "device_id": "42cdda32a2a3428e86c2e27699d79ead",
             "disabled_by": null,
             "entity_id": "media_player.tv_uppe2",
+            "area_id": "some_area_id",
             "name": null,
             "icon": null,
             "platform": "cast"

--- a/tests/HassClient.Unit.Tests/HassClientTests.cs
+++ b/tests/HassClient.Unit.Tests/HassClientTests.cs
@@ -1285,6 +1285,7 @@ namespace HassClient.Unit.Tests
             Assert.NotNull(result);
             Assert.NotNull(first);
             Assert.Equal("42cdda32a2a3428e86c2e27699d79ead", first.DeviceId);
+            Assert.Equal("some_area_id", first.AreaId);
             Assert.Equal("media_player.tv_uppe2", first.EntityId);
 
             Assert.Equal(2, result.Count);


### PR DESCRIPTION
Adding area_id to HassEntity. Area cannot be handled correctly if this is not handled